### PR TITLE
Sourcery token: add links to the dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "sourcery.token": {
           "type": "string",
           "default": "",
-          "description": "Sourcery token"
+          "description": "Sourcery token. You can find your token at https://sourcery.ai/dashboard"
         },
         "sourcery.metricsEnabled": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 import * as path from 'path';
 import { getExecutablePath } from './executable';
 
-import {Uri, workspace, window, Disposable, ExtensionContext, commands, version, extensions} from 'vscode';
+import { Uri, workspace, window, Disposable, ExtensionContext, commands, version, extensions } from 'vscode';
 import {
     LanguageClient,
     LanguageClientOptions,
@@ -55,7 +55,7 @@ function createLangServer(context: ExtensionContext): LanguageClient {
         window.showTextDocument(readmePath);
         const result = window.showInputBox({
             placeHolder: 'Sourcery Token',
-            prompt: 'Follow the instructions below to get your token.',
+            prompt: 'Get your token from https://sourcery.ai/dashboard',
             ignoreFocusOut: true
         });
         result.then(function (value) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ function createLangServer(context: ExtensionContext): LanguageClient {
         window.showTextDocument(readmePath);
         const result = window.showInputBox({
             placeHolder: 'Sourcery Token',
-            prompt: 'Get your token from https://sourcery.ai/dashboard',
+            prompt: 'Get your token from https://sourcery.ai/signup',
             ignoreFocusOut: true
         });
         result.then(function (value) {

--- a/welcome-to-sourcery.py
+++ b/welcome-to-sourcery.py
@@ -2,7 +2,7 @@
 
 # Sourcery Installation
 
-# 1. Go to https://sourcery.ai/download/?editor=vscode to get a free token.
+# 1. Go to https://sourcery.ai/dashboard to get a free token.
 # 2. Enter the token into the box above, or search for `sourcery` in the
 #    settings and enter the token into the `Sourcery Token` field.
 
@@ -28,7 +28,7 @@ def refactoring_example(spellbook):
 # code quality - hover over the function definition above to see this report.
 
 # For more details check out our documentation here:
-# https://github.com/sourcery-ai/sourcery/wiki/Sourcery-Tutorial
+# https://docs.sourcery.ai/
 
 # Now open up some Python files and look out for the suggestions!
 

--- a/welcome-to-sourcery.py
+++ b/welcome-to-sourcery.py
@@ -2,7 +2,7 @@
 
 # Sourcery Installation
 
-# 1. Go to https://sourcery.ai/dashboard to get a free token.
+# 1. Go to https://sourcery.ai/signup to get a free token.
 # 2. Enter the token into the box above, or search for `sourcery` in the
 #    settings and enter the token into the `Sourcery Token` field.
 


### PR DESCRIPTION
Add a text with the dashboard's URL to:

* the input box for the Sourcery token (shown after the installation)
* the description of the setting Sourcery token

welcome-to-sourcery.py

* Change the link: VSCode installation instructions => Dashboard
* old docs => new docs