### PR TITLE
fix: Only trigger sourcery on files that are newly created or on the file system

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,7 @@ function createLangServer(context: ExtensionContext): LanguageClient {
     };
 
     const clientOptions: LanguageClientOptions = {
-        documentSelector: ['python'],
+        documentSelector: [{language: 'python', scheme: 'file'}, {language: 'python', scheme: 'untitled'}],
         synchronize: {
             configurationSection: 'sourcery'
         },


### PR DESCRIPTION
Sourcery is currently suggesting improvements on all python files, including diffs.

Amend the extension to only trigger on files on disk or newly created files.

Addresses #61 