### PR TITLE
chore: Add yarn run vscode_local command

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "vscode:prepublish": "tsc -p ./",
     "vscode:uninstall": "node ./out/uninstall",
     "compile": "tsc -watch -p ./",
-    "vscode": "npm run vscode:prepublish && VSCODE=$(which code-insiders || which code || echo echo ERROR: neither the code nor code-insiders vscode executable is installed); USER=dummy-dont-share-vscode-instance \"$VSCODE\" --user-data-dir=$PWD/.vscode-dev/user-data --verbose --extensionHomePath=$PWD/.vscode-dev/extensions --extensionDevelopmentPath=$PWD $*"
+    "vscode": "npm run vscode:prepublish && VSCODE=$(which code-insiders || which code || echo echo ERROR: neither the code nor code-insiders vscode executable is installed); USER=dummy-dont-share-vscode-instance \"$VSCODE\" --user-data-dir=$PWD/.vscode-dev/user-data --verbose --extensionHomePath=$PWD/.vscode-dev/extensions --extensionDevelopmentPath=$PWD $*",
+    "vscode_local": "SOURCERY_EXECUTABLE=../core/run-sourcery.sh yarn run vscode"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",

--- a/src/executable.ts
+++ b/src/executable.ts
@@ -5,24 +5,29 @@ import * as fs from 'fs';
 
 
 export function getExecutablePath(): string {
-    const activePath = path.join(__dirname, "..", "sourcery_binaries/active");
+  if (process.env.SOURCERY_EXECUTABLE) {
+        console.log(process.env.SOURCERY_EXECUTABLE)
+        return process.env.SOURCERY_EXECUTABLE;
+    }
+    const sourcery_binaries = path.join(__dirname, "..", "sourcery_binaries");
+    const activePath = path.join(sourcery_binaries, "active");
     if (fs.existsSync(activePath)) {
         if (process.platform == 'win32') {
-            return 'active/sourcery.exe'
+            return path.join(activePath, 'sourcery.exe')
         } else if (process.platform == 'darwin') {
-            return 'active/sourcery'
+            return path.join(activePath, 'sourcery')
         } else {
             // Assume everything else is linux compatible
-            return 'active/sourcery'
+            return path.join(activePath, 'sourcery')
         }
     } else {
         if (process.platform == 'win32') {
-            return 'install/win/sourcery.exe'
+            return path.join(sourcery_binaries, 'install/win/sourcery.exe')
         } else if (process.platform == 'darwin') {
-            return 'install/mac/sourcery'
+            return path.join(sourcery_binaries, 'install/mac/sourcery')
         } else {
             // Assume everything else is linux compatible
-            return 'install/linux/sourcery'
+            return path.join(sourcery_binaries, 'install/linux/sourcery')
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,8 +37,12 @@ function createLangServer(context: ExtensionContext): LanguageClient {
     };
 
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{language: 'python', scheme: 'file'}, {language: 'python', scheme: 'untitled'},
-            { scheme: 'vscode-notebook-cell', language: 'python' }],
+        documentSelector: [
+            {language: 'python', scheme: 'file'},
+            {language: 'python', scheme: 'untitled'},
+            {language: 'python', scheme: 'vscode-notebook-cell' },
+            {language: 'yaml', pattern: '**/.sourcery.yaml'}
+        ],
         synchronize: {
             configurationSection: 'sourcery'
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,8 @@ function createLangServer(context: ExtensionContext): LanguageClient {
     const packageJson = extensions.getExtension('sourcery.sourcery').packageJSON;
     const extensionVersion = packageJson.version;
 
-    const command = path.join(__dirname, "..", "sourcery_binaries/" + getExecutablePath());
+    const command = getExecutablePath();
+
     const serverOptions: ServerOptions = {
         command,
         args: ['lsp'],


### PR DESCRIPTION
Assuming core Sourcery is in the sibling folder `../core` then
`yarn run vscode_local` will start this extension with the code
checked out in core.