### PR TITLE
fix: re-enable extension for python notebook cells

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,6 @@ function createLangServer(context: ExtensionContext): LanguageClient {
     const extensionVersion = packageJson.version;
 
     const command = path.join(__dirname, "..", "sourcery_binaries/" + getExecutablePath());
-
     const serverOptions: ServerOptions = {
         command,
         args: ['lsp'],
@@ -37,7 +36,8 @@ function createLangServer(context: ExtensionContext): LanguageClient {
     };
 
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{language: 'python', scheme: 'file'}, {language: 'python', scheme: 'untitled'}],
+        documentSelector: [{language: 'python', scheme: 'file'}, {language: 'python', scheme: 'untitled'},
+            { scheme: 'vscode-notebook-cell', language: 'python' }],
         synchronize: {
             configurationSection: 'sourcery'
         },


### PR DESCRIPTION
Ensure that Python notebook cells in notebooks are sent through to Sourcery so that we can suggest things in them.