### PR TITLE
fix: remove unimplemented command

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,11 +121,6 @@
 				"command": "sourcery.config.create",
 				"title": "Create a default Sourcery configuration file for your project",
 				"category": "Sourcery"
-			},
-			{
-				"command": "sourcery.config.open",
-				"title": "Open the Sourcery configuration file for your project",
-				"category": "Sourcery"
 			}
 		],
 		"submenus": [


### PR DESCRIPTION
I added a stub command and forgot to remove it - at the moment it errors if you call it.