### PR TITLE
feat: set the diagnostic collection name in the languageclientoptions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,7 @@ function createLangServer(context: ExtensionContext): LanguageClient {
     };
 
     const clientOptions: LanguageClientOptions = {
+        diagnosticCollectionName: "sourcery",
         documentSelector: [
             {language: 'python', scheme: 'file'},
             {language: 'javascript', scheme: 'file'},


### PR DESCRIPTION
This sets the 'owner' property on diagnostics, which should hopefully resolve https://github.com/sourcery-ai/sourcery-vscode/issues/121
There's more context in that issue.