### PR TITLE
chore: Add categories and tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	"categories": [
 		"Linters",
 		"Machine Learning",
+		"Other",
 		"Programming Languages",
 		"Snippets"
 	],

--- a/package.json
+++ b/package.json
@@ -12,14 +12,27 @@
 	"publisher": "sourcery",
 	"icon": "sourcery-icon.png",
 	"keywords": [
-		"Python",
-		"refactoring"
+		"ai",
+		"copilot",
+		"tabnine",
+		"python",
+		"javascript",
+		"jupyter",
+		"node.js",
+		"nodejs",
+		"node",
+		"refactor",
+		"refactoring",
+		"typescript"
 	],
 	"engines": {
 		"vscode": "^1.76.0"
 	},
 	"categories": [
-		"Other"
+		"Linters",
+		"Machine Learning",
+		"Programming Languages",
+		"Snippets"
 	],
 	"activationEvents": [
 		"onLanguage:python",


### PR DESCRIPTION
The current [marketplace search](https://marketplace.visualstudio.com/search?term=refactor&target=VSCode&category=Linters&sortBy=Relevance) doesn't show Sourcery in Linters for `refactor` search term.

This adds a bunch of keywords and categories.