### PR TITLE
ci: add action to publish pre-releases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,59 @@
+name: Pre-release VSIX
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+
+jobs:
+  publish-vsix:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.SOURCERY_RELEASE_TOKEN }}
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '14'
+
+    - run: yarn install --frozen-lockfile
+
+    - name: Update binaries
+      run: |
+        ./download-binaries.sh ${{ github.event.inputs.version }}
+
+    - name: Update version number
+      run: yarn run bump ${{ github.event.inputs.version }}
+
+    - name: Package VSCode extension
+      run: yarn run vsce package
+
+    - name: Upload archive
+      uses: actions/upload-artifact@v3
+      with:
+        path: sourcery-${{ github.event.inputs.version }}.vsix
+
+    - name: Create release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: v${{ github.event.inputs.version }}
+        name: Sourcery ${{ github.event.inputs.version }}
+        body: v${{ github.event.inputs.version }}
+        prerelease: true
+        artifacts: sourcery-${{ github.event.inputs.version }}.vsix
+        artifactContentType: raw
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.SOURCERY_RELEASE_TOKEN }}
+
+    - name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        text: Publish VS Code extension pre-release v${{ github.event.inputs.version }} - ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
+      if: always()


### PR DESCRIPTION
## Checklist

- [ ] If `package.json` or `yarn.lock` have changed, then test the VSIX built by `yarn run vsce package` works from a direct install
