### PR TITLE
ci: fix pre-release workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,9 +26,6 @@ jobs:
       run: |
         ./download-binaries.sh ${{ github.event.inputs.version }}
 
-    - name: Update version number
-      run: yarn run bump ${{ github.event.inputs.version }}
-
     - name: Package VSCode extension
       run: yarn run vsce package
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Package VSCode extension
       run: yarn run vsce package
 
+    - name: Rename packaged VSIX file
+      run: mv sourcery-*.vsix sourcery-${{ github.event.inputs.version }}.vsix
+
     - name: Upload archive
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -18,7 +18,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: latest
 
     - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -54,6 +54,7 @@ jobs:
       with:
         status: ${{ job.status }}
         text: Publish VS Code extension pre-release v${{ github.event.inputs.version }} - ${{ job.status }}
+        fields: repo,commit,workflow,job
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
       if: always()


### PR DESCRIPTION
## Checklist

- [ ] If `package.json` or `yarn.lock` have changed, then test the VSIX built by `yarn run vsce package` works from a direct install
