### PR TITLE
fix: scroll message window to bottom, unless the user has scrolled up

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -25,6 +25,7 @@
   margin: 0;
   display: flex;
   flex-direction: column;
+  overflow-y: scroll;
 }
 
 .sidebar__chat-assistant--chat-bubble {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -252,7 +252,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
 
 			</head>
 			<body class="sidebar__chat-assistant-body">
-                <section class="sidebar__section-container active" data-section="chat-assistant">
+                <section id="message-container" class="sidebar__section-container active" data-section="chat-assistant">
                   <ul class="sidebar__chat-assistant--dialogue-container">
   
                   </ul>

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -254,7 +254,8 @@ export class ChatProvider implements vscode.WebviewViewProvider {
 			<body class="sidebar__chat-assistant-body">
                 <section id="message-container" class="sidebar__section-container active" data-section="chat-assistant">
                   <ul class="sidebar__chat-assistant--dialogue-container">
-  
+                    
+                    <li id="anchor"></li>
                   </ul>
                 </section>
                 <footer class="sidebar__chat-assistant--footer">

--- a/src/webview/chat.js
+++ b/src/webview/chat.js
@@ -28,6 +28,8 @@ const chatAvatar = `<div class="sidebar__chat-assistant--chat-avatar-container">
     cancelButton.onclick = sendCancelRequest;
   }
 
+  const messageContainer = document.getElementById("message-container");
+
   // Hold the current assistant message so we can direct streaming responses to it
   let currentAssistantMessage;
   let thinkingMessage;
@@ -121,15 +123,11 @@ const chatAvatar = `<div class="sidebar__chat-assistant--chat-avatar-container">
     if (!currentAssistantMessage) {
       return;
     }
-    const messageContainer = document.getElementById("message-container");
+    const { scrollTop, clientHeight, scrollHeight } = messageContainer;
     const isScrolledToBottom =
-      messageContainer.scrollTop + messageContainer.clientHeight <=
-        messageContainer.scrollHeight &&
-      messageContainer.scrollTop + messageContainer.clientHeight >=
-        messageContainer.scrollHeight - 18; // give a bit of a buffer
+      Math.abs(scrollHeight - clientHeight - scrollTop) <= 18; // give a bit of a buffer
     if (isScrolledToBottom) {
-      messageContainer.scrollTop =
-        messageContainer.scrollHeight - messageContainer.clientHeight;
+      messageContainer.scrollTop = scrollHeight - clientHeight;
     }
   }
 

--- a/src/webview/chat.js
+++ b/src/webview/chat.js
@@ -61,7 +61,7 @@ const LINE_HEIGHT = 36;
   window.addEventListener("message", (event) => {
     const message = event.data;
     if (message.command === "add_result") {
-      addMessageToUI(message.result);
+      withStickyScroll(addMessageToUI)(message.result);
     } else if (message.command === "clear_chat") {
       clearAllMessages();
     } else if (message.command === "focus") {
@@ -98,7 +98,6 @@ const LINE_HEIGHT = 36;
 
   // Function to add a user message to the chat interface
   function addUserMessageToUI(message) {
-    const { scrollHeight: scrollHeightBefore } = messageContainer;
     const templateMessage = `
             ${chatAvatar}
             <div class="sidebar__chat-assistant--chat-bubble-content-user">
@@ -112,8 +111,6 @@ const LINE_HEIGHT = 36;
     );
     userMessageElement.innerHTML = templateMessage;
     chatContainer.append(userMessageElement);
-    const { scrollHeight: scrollHeightAfter } = messageContainer;
-    stickyScrollToBottom(scrollHeightAfter - scrollHeightBefore);
   }
 
   function addMessageToUI(result) {
@@ -160,7 +157,6 @@ const LINE_HEIGHT = 36;
     if (currentAssistantMessage != null && message.outcome !== "error") {
       replaceCurrentAssistantMessage();
     } else {
-      const { scrollHeight: scrollHeightBefore } = messageContainer;
       const templateContents = `
             <!-- Using an absolute sourcery.ai URL for now, since I'm not sure how does VS Code extensions handle static assets. -->
             ${assistantAvatar}
@@ -187,21 +183,16 @@ const LINE_HEIGHT = 36;
         ".sidebar__chat-assistant--chat-bubble-text"
       );
       replaceCurrentAssistantMessage();
-      const { scrollHeight: scrollHeightAfter } = messageContainer;
-      stickyScrollToBottom(scrollHeightAfter - scrollHeightBefore);
     }
   }
 
   function addAssistantThinkingMessageToUI() {
-    const { scrollHeight: scrollHeightBefore } = messageContainer;
     if (thinkingMessage != null) {
       thinkingMessage.remove();
       thinkingMessage = null;
     }
     thinkingMessage = thinkingMessageElement;
     chatContainer.append(thinkingMessage);
-    const { scrollHeight: scrollHeightAfter } = messageContainer;
-    stickyScrollToBottom(scrollHeightAfter - scrollHeightBefore);
   }
 
   // Enable/Disable send button depending on whether text area is empty

--- a/src/webview/chat.js
+++ b/src/webview/chat.js
@@ -104,7 +104,7 @@ const chatAvatar = `<div class="sidebar__chat-assistant--chat-avatar-container">
     );
     userMessageElement.innerHTML = templateMessage;
     chatContainer.append(userMessageElement);
-    userMessageElement.scrollIntoView();
+    stickyScrollToBottom();
   }
 
   function addMessageToUI(result) {
@@ -113,6 +113,23 @@ const chatAvatar = `<div class="sidebar__chat-assistant--chat-avatar-container">
     } else {
       addUserMessageToUI(result.textContent);
       addAssistantThinkingMessageToUI();
+    }
+  }
+
+  // If we're already at the bottom, scroll the bottom into view
+  function stickyScrollToBottom() {
+    if (!currentAssistantMessage) {
+      return;
+    }
+    const messageContainer = document.getElementById("message-container");
+    const isScrolledToBottom =
+      messageContainer.scrollTop + messageContainer.clientHeight <=
+        messageContainer.scrollHeight &&
+      messageContainer.scrollTop + messageContainer.clientHeight >=
+        messageContainer.scrollHeight - 18; // give a bit of a buffer
+    if (isScrolledToBottom) {
+      messageContainer.scrollTop =
+        messageContainer.scrollHeight - messageContainer.clientHeight;
     }
   }
 
@@ -128,7 +145,7 @@ const chatAvatar = `<div class="sidebar__chat-assistant--chat-avatar-container">
       currentAssistantMessage.innerHTML = message.textContent;
 
       // Scroll the bottom into view
-      currentAssistantMessage.scrollIntoView(false);
+      stickyScrollToBottom();
     };
 
     if (currentAssistantMessage != null && message.outcome !== "error") {
@@ -170,7 +187,7 @@ const chatAvatar = `<div class="sidebar__chat-assistant--chat-avatar-container">
     }
     thinkingMessage = thinkingMessageElement;
     chatContainer.append(thinkingMessage);
-    thinkingMessage.scrollIntoView();
+    stickyScrollToBottom();
   }
 
   // Enable/Disable send button depending on whether text area is empty


### PR DESCRIPTION
The effect is quite nice - it sticks to the bottom as expected, but you can smoothly scroll up.