### PR TITLE
feat: improve appearance of markdown formatting

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -85,7 +85,8 @@
   border-radius: var(--spacing-xs);
 }
 
-.sidebar__chat-assistant--chat-bubble-content-user .sidebar__chat-assistant--chat-bubble-text {
+.sidebar__chat-assistant--chat-bubble-content-user
+  .sidebar__chat-assistant--chat-bubble-text {
   white-space: pre-wrap;
 }
 
@@ -112,12 +113,10 @@
   font-weight: bold;
 }
 
-
-.sidebar__chat-assistant--chat-bubble-text :is(h1, h2, h3, h4, h5, h6):not(:first-child) {
+.sidebar__chat-assistant--chat-bubble-text
+  :is(h1, h2, h3, h4, h5, h6):not(:first-child) {
   margin-top: var(--spacing-md);
 }
-
-
 
 .sidebar__chat-assistant--chat-bubble-text :is(ol, ul) {
   margin-left: 1.5em;

--- a/media/chat.css
+++ b/media/chat.css
@@ -108,13 +108,19 @@
 }
 
 .sidebar__chat-assistant--chat-bubble-text :is(h1, h2, h3, h4, h5, h6) {
-  margin-top: 0.5em;
   font-size: 1em;
   font-weight: bold;
 }
 
+
+.sidebar__chat-assistant--chat-bubble-text :is(h1, h2, h3, h4, h5, h6):not(:first-child) {
+  margin-top: var(--spacing-md);
+}
+
+
+
 .sidebar__chat-assistant--chat-bubble-text :is(ol, ul) {
-  padding-left: 1.5em;
+  margin-left: 1.5em;
 }
 
 .sidebar__chat-assistant--chat-bubble-text li {
@@ -131,11 +137,15 @@
 }
 
 .sidebar__chat-assistant--chat-bubble-text pre {
-  background-color: var(--vscode-editor-background);
   margin: 0;
-  border-radius: var(--spacing-xs);
   overflow-x: auto;
   width: 100%;
+  background-color: var(--vscode-editor-background);
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: var(--spacing-xs);
+}
+
+.sidebar__chat-assistant--chat-bubble-text pre code {
 }
 
 .sidebar__chat-assistant--code-block {
@@ -270,12 +280,13 @@
   border-radius: var(--spacing-xxs);
   margin-bottom: var(--spacing-xs);
   outline: none;
-  background-color: var(--vscode-button-secondaryBackground);
-  color: var(--vscode-button-secondaryForeground);
+  background-color: transparent;
+  color: var(--vscode-foreground);
 }
 
 .sidebar__chat-assistant--cancel-button:hover {
-  background-color: var(--vscode-button-secondaryHoverBackground);
+  background-color: transparent;
+  opacity: 0.8;
 }
 
 .sidebar__chat-assistant--cancel-button:disabled {
@@ -284,11 +295,12 @@
 }
 
 .sidebar__chat-assistant--cancel-button:hover:disabled {
-  background-color: var(--vscode-button-secondaryBackground);
+  background-color: transparent;
+  opacity: 1;
 }
 
 .sidebar__chat-assistant--regenerate-button-icon {
-  fill: var(--vscode-button-secondaryForeground);
+  fill: var(--vscode-foreground);
   width: var(--spacing-lg);
   margin-right: var(--spacing-xs);
 }

--- a/media/chat.css
+++ b/media/chat.css
@@ -85,6 +85,10 @@
   border-radius: var(--spacing-xs);
 }
 
+.sidebar__chat-assistant--chat-bubble-content-user .sidebar__chat-assistant--chat-bubble-text {
+  white-space: pre-wrap;
+}
+
 .sidebar__chat-assistant--chat-bubble-text {
   margin: 0;
   color: var(--vscode-settings-textInputForeground);
@@ -99,9 +103,22 @@
   background: transparent;
 }
 
-.sidebar__chat-assistant--code-block-container {
-  background-color: var(--vscode-editor-background);
-  color: var(--vscode-sideBar-foreground);
+.sidebar__chat-assistant--chat-bubble-text *:not(:last-child) {
+  margin-bottom: var(--spacing-sm);
+}
+
+.sidebar__chat-assistant--chat-bubble-text :is(h1, h2, h3, h4, h5, h6) {
+  margin-top: 0.5em;
+  font-size: 1em;
+  font-weight: bold;
+}
+
+.sidebar__chat-assistant--chat-bubble-text :is(ol, ul) {
+  padding-left: 1.5em;
+}
+
+.sidebar__chat-assistant--chat-bubble-text li {
+  /*padding-left: 1.5em;*/
 }
 
 .sidebar__chat-assistant--chat-bubble-text *:not(:last-child) {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -11,7 +11,7 @@ marked.use(
     langPrefix: "hljs language-",
     highlight(code, lang) {
       const language = hljs.getLanguage(lang) ? lang : "plaintext";
-      return hljs.highlightAuto(code).value;
+      return hljs.highlight(code, { language }).value;
     },
   })
 );


### PR DESCRIPTION
* Titles are smaller, bold, and have a tiny bit more space above each one 
* Lists fit inside the bubble correctly
* Only user messages are pre-wrapped - assistant messages are assumed to be markdown formatted
* Code blocks take on the color of the editor (this seems to work nicely with the highlightjs settings)
* Cancel button styles updated to work a bit better

I noticed that if you switch color themes, the code blocks continue in the old theme until the editor is restarted. I think that's alright, most people aren't deliberately switching between themes frequently, and restarting is an easy enough workaround.