### PR TITLE
feat: focus chat window on all chat requests

### DIFF
--- a/src/ask-sourcery.ts
+++ b/src/ask-sourcery.ts
@@ -4,28 +4,26 @@ import { ChatRequest } from "./chat";
 
 export function askSourceryCommand(recipes: Recipe[], contextRange?) {
   showAskSourceryQuickPick(recipes).then((result: any) => {
-    vscode.commands.executeCommand("sourcery.chat.focus").then(() => {
-      let request: ChatRequest;
-      if ("id" in result) {
-        request = {
-          type: "recipe_request",
-          data: {
-            kind: "recipe_request",
-            name: result.label,
-            id: result.id,
-          },
-          context_range: contextRange,
-        };
-      } else {
-        request = {
-          type: "chat_request",
-          data: { kind: "user_message", message: result.label },
-          context_range: contextRange,
-        };
-      }
+    let request: ChatRequest;
+    if ("id" in result) {
+      request = {
+        type: "recipe_request",
+        data: {
+          kind: "recipe_request",
+          name: result.label,
+          id: result.id,
+        },
+        context_range: contextRange,
+      };
+    } else {
+      request = {
+        type: "chat_request",
+        data: { kind: "user_message", message: result.label },
+        context_range: contextRange,
+      };
+    }
 
-      vscode.commands.executeCommand("sourcery.chat_request", request);
-    });
+    vscode.commands.executeCommand("sourcery.chat_request", request);
   });
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -406,29 +406,31 @@ function registerCommands(
     commands.registerCommand(
       "sourcery.chat_request",
       (message: ChatRequest) => {
-        // Use the editor selection unless a range was passed through in
-        // the message
-        let selectionLocation = getSelectionLocation();
-        if (message.context_range != null) {
-          selectionLocation = {
-            uri: selectionLocation.uri,
-            range: message.context_range,
-          };
-        }
-        let { activeFile, allFiles } = activeFiles();
+        vscode.commands.executeCommand("sourcery.chat.focus").then(() => {
+          // Use the editor selection unless a range was passed through in
+          // the message
+          let selectionLocation = getSelectionLocation();
+          if (message.context_range != null) {
+            selectionLocation = {
+              uri: selectionLocation.uri,
+              range: message.context_range,
+            };
+          }
+          let { activeFile, allFiles } = activeFiles();
 
-        let request: ExecuteCommandParams = {
-          command: "sourcery/chat/request",
-          arguments: [
-            {
-              message: message,
-              selected: selectionLocation,
-              active_file: activeFile,
-              all_open_files: allFiles,
-            },
-          ],
-        };
-        languageClient.sendRequest(ExecuteCommandRequest.type, request);
+          let request: ExecuteCommandParams = {
+            command: "sourcery/chat/request",
+            arguments: [
+              {
+                message: message,
+                selected: selectionLocation,
+                active_file: activeFile,
+                all_open_files: allFiles,
+              },
+            ],
+          };
+          languageClient.sendRequest(ExecuteCommandRequest.type, request);
+        });
       }
     )
   );


### PR DESCRIPTION
This means we can trigger chat requests from the binary and it still focuses correctly.

## Checklist

- [ ] If `package.json` or `yarn.lock` have changed, then test the VSIX built by `yarn run vsce package` works from a direct install
