### PR TITLE
feat: add config and command to toggle off code lens

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,11 @@
 				"category": "Sourcery"
 			},
 			{
+				"command": "sourcery.chat.toggleCodeLens",
+				"title": "Toggle Sourcery Code Lens",
+				"category": "Sourcery"
+			},
+			{
 				"command": "sourcery.scan.selectLanguage",
 				"title": "Select Language",
 				"category": "Sourcery"
@@ -360,6 +365,10 @@
 					"when": "sourcery.features.coding_assistant"
 				},
 				{
+					"command": "sourcery.chat.toggleCodeLens",
+					"when": "sourcery.features.coding_assistant"
+				},
+				{
 					"command": "sourcery.scan.selectLanguage",
 					"when": "false"
 				},
@@ -385,6 +394,11 @@
 					"type": "string",
 					"default": "",
 					"description": "Sourcery token. You can find your token at https://sourcery.ai/dashboard"
+				},
+				"sourcery.codeLens": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show code lens for Sourcery's coding assistant."
 				},
 				"sourcery.ruleType.refactorings": {
 					"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
 			},
 			{
 				"command": "sourcery.chat.toggleCodeLens",
-				"title": "Toggle Sourcery Code Lens",
+				"title": "Toggle Code Lens for Coding Assistant",
 				"category": "Sourcery"
 			},
 			{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,10 @@ import { askSourceryCommand } from "./ask-sourcery";
 
 function createLangServer(): LanguageClient {
   const token = workspace.getConfiguration("sourcery").get<string>("token");
+  const showCodeLens = workspace
+    .getConfiguration("sourcery")
+    .get<boolean>("codeLens");
+
   const packageJson = extensions.getExtension("sourcery.sourcery").packageJSON;
   const extensionVersion = packageJson.version;
 
@@ -76,6 +80,7 @@ function createLangServer(): LanguageClient {
       editor_version: "vscode " + version,
       extension_version: extensionVersion,
       telemetry_enabled: env.isTelemetryEnabled,
+      show_code_lens: showCodeLens,
     },
   };
 
@@ -221,6 +226,14 @@ function registerCommands(
     commands.registerCommand("sourcery.chat.ask", (arg?) => {
       let contextRange = arg && "start" in arg ? arg : null;
       askSourceryCommand(recipeProvider.recipes, contextRange);
+    })
+  );
+
+  context.subscriptions.push(
+    commands.registerCommand("sourcery.chat.toggleCodeLens", () => {
+      const config = vscode.workspace.getConfiguration();
+      const currentValue = config.get("sourcery.codeLens");
+      config.update("sourcery.codeLens", !currentValue);
     })
   );
 


### PR DESCRIPTION
Review with https://github.com/sourcery-ai/core/pull/2831

## Checklist

- [ ] If `package.json` or `yarn.lock` have changed, then test the VSIX built by `yarn run vsce package` works from a direct install
