### PR TITLE
refactor: consolidate coding assistant extension commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,11 +224,6 @@
 				"category": "Sourcery"
 			},
 			{
-				"command": "sourcery.chat.clearCodeReview",
-				"title": "Clear",
-				"category": "Sourcery"
-			},
-			{
 				"command": "sourcery.troubleshoot.reset",
 				"title": "Reset",
 				"category": "Sourcery"
@@ -358,10 +353,6 @@
 				},
 				{
 					"command": "sourcery.scan.toggleAdvanced",
-					"when": "false"
-				},
-				{
-					"command": "sourcery.chat.clearCodeReview",
 					"when": "false"
 				},
 				{

--- a/src/ask-sourcery.ts
+++ b/src/ask-sourcery.ts
@@ -22,7 +22,11 @@ export function askSourceryCommand(recipes: Recipe[], contextRange?) {
       };
     }
 
-    vscode.commands.executeCommand("sourcery.chat_request", request);
+    vscode.commands.executeCommand("sourcery.coding_assistant", {
+      view: "chat",
+      request: "sendMessage",
+      message: request,
+    });
   });
 }
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -137,33 +137,55 @@ export class ChatProvider implements vscode.WebviewViewProvider {
       async (request: ServerRequest | ExtensionRequest) => {
         switch (request.type) {
           case "context/contextRequest": {
-            vscode.commands.executeCommand(
-              "sourcery.coding_assistant.context_request"
-            );
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "app",
+              request: "context",
+            });
             break;
           }
           case "optIn/enableRequest": {
-            vscode.commands.executeCommand("sourcery.coding_assistant.opt_in");
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "app",
+              request: "optIn",
+            });
             break;
           }
           case "chat/messageRequest": {
-            vscode.commands.executeCommand("sourcery.chat_request", request);
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "chat",
+              request: "sendMessage",
+              message: request,
+            });
             break;
           }
           case "chat/initialiseRequest": {
-            vscode.commands.executeCommand("sourcery.initialise_chat");
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "chat",
+              request: "initialise",
+            });
             break;
           }
           case "chat/clearRequest": {
-            vscode.commands.executeCommand("sourcery.chat.clearChat");
+            this.clearChat();
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "chat",
+              request: "clear",
+            });
             break;
           }
           case "chat/cancelRequest": {
-            vscode.commands.executeCommand("sourcery.chat_cancel_request");
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "chat",
+              request: "cancel",
+            });
             break;
           }
           case "recipes/recipeRequest": {
-            vscode.commands.executeCommand("sourcery.chat_request", request);
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "chat",
+              request: "sendMessage",
+              message: request,
+            });
             break;
           }
           case "recipes/initialiseRequest": {
@@ -183,15 +205,26 @@ export class ChatProvider implements vscode.WebviewViewProvider {
             break;
           }
           case "review/reviewRequest": {
-            vscode.commands.executeCommand("sourcery.review_request", request);
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "review",
+              request: "sendMessage",
+              message: request,
+            });
             break;
           }
           case "review/cancelRequest": {
-            vscode.commands.executeCommand("sourcery.review_cancel_request");
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "review",
+              request: "cancel",
+            });
             break;
           }
           case "review/clearRequest": {
-            vscode.commands.executeCommand("sourcery.chat.clearCodeReview");
+            this.clearReview();
+            vscode.commands.executeCommand("sourcery.coding_assistant", {
+              view: "review",
+              request: "clear",
+            });
             break;
           }
           case "openLinkRequest": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,54 +235,6 @@ function registerCommands(
   );
 
   context.subscriptions.push(
-    commands.registerCommand(
-      "sourcery.coding_assistant.context_request",
-      () => {
-        let request: ExecuteCommandParams = {
-          command: "sourcery.coding_assistant",
-          arguments: [{ view: "app", request: "context" }],
-        };
-        languageClient.sendRequest(ExecuteCommandRequest.type, request);
-      }
-    )
-  );
-
-  context.subscriptions.push(
-    commands.registerCommand("sourcery.coding_assistant.opt_in", () => {
-      let request: ExecuteCommandParams = {
-        command: "sourcery.coding_assistant",
-        arguments: [{ view: "app", request: "optIn" }],
-      };
-      languageClient.sendRequest(ExecuteCommandRequest.type, request);
-    })
-  );
-
-  context.subscriptions.push(
-    commands.registerCommand("sourcery.chat.clearChat", () => {
-      let request: ExecuteCommandParams = {
-        command: "sourcery.coding_assistant",
-        arguments: [{ view: "chat", request: "clear" }],
-      };
-      chatProvider.clearChat();
-      languageClient.sendRequest(ExecuteCommandRequest.type, request);
-    })
-  );
-
-  context.subscriptions.push(
-    commands.registerCommand("sourcery.chat.clearCodeReview", () => {
-      let request: ExecuteCommandParams = {
-        command: "sourcery.coding_assistant",
-        arguments: [{ view: "review", request: "clear" }],
-      };
-      languageClient
-        .sendRequest(ExecuteCommandRequest.type, request)
-        .then(() => {
-          chatProvider.clearReview();
-        });
-    })
-  );
-
-  context.subscriptions.push(
     commands.registerCommand("sourcery.chat.ask", (arg?) => {
       let contextRange = arg && "start" in arg ? arg : null;
       askSourceryCommand(chatProvider.recipes, contextRange);
@@ -481,24 +433,22 @@ function registerCommands(
   );
 
   context.subscriptions.push(
-    commands.registerCommand("sourcery.initialise_chat", () => {
-      let request: ExecuteCommandParams = {
-        command: "sourcery.coding_assistant",
-        arguments: [{ view: "chat", request: "initialise" }],
-      };
-      languageClient.sendRequest(ExecuteCommandRequest.type, request);
-    })
-  );
-
-  context.subscriptions.push(
     commands.registerCommand(
-      "sourcery.chat_request",
-      (message: ServerRequest) => {
+      "sourcery.coding_assistant",
+      ({
+        view,
+        request,
+        message,
+      }: {
+        view: string;
+        request: string;
+        message?: ServerRequest;
+      }) => {
         vscode.commands.executeCommand("sourcery.chat.focus").then(() => {
           // Use the editor selection unless a range was passed through in
           // the message
           let selectionLocation = getSelectionLocation();
-          if (message.context_range != null) {
+          if (message?.context_range) {
             selectionLocation = {
               uri: selectionLocation.uri,
               range: message.context_range,
@@ -506,60 +456,24 @@ function registerCommands(
           }
           let { activeFile, allFiles } = activeFiles();
 
-          let request: ExecuteCommandParams = {
+          let params: ExecuteCommandParams = {
             command: "sourcery.coding_assistant",
             arguments: [
               {
-                view: "chat",
-                request: "sendMessage",
-                message: message,
+                view,
+                request,
+                message,
                 selected: selectionLocation,
                 active_file: activeFile,
                 all_open_files: allFiles,
               },
             ],
           };
-          languageClient.sendRequest(ExecuteCommandRequest.type, request);
+          console.log(params);
+          languageClient.sendRequest(ExecuteCommandRequest.type, params);
         });
       }
     )
-  );
-
-  context.subscriptions.push(
-    commands.registerCommand(
-      "sourcery.review_request",
-      (message: ServerRequest) => {
-        let request: ExecuteCommandParams = {
-          command: "sourcery.coding_assistant",
-          arguments: [
-            {
-              view: "review",
-              request: "sendMessage",
-              message: message,
-            },
-          ],
-        };
-        languageClient.sendRequest(ExecuteCommandRequest.type, request);
-      }
-    )
-  );
-
-  context.subscriptions.push(
-    commands.registerCommand("sourcery.chat_cancel_request", () => {
-      languageClient.sendRequest(ExecuteCommandRequest.type, {
-        command: "sourcery.coding_assistant",
-        arguments: [{ view: "chat", request: "cancel" }],
-      });
-    })
-  );
-
-  context.subscriptions.push(
-    commands.registerCommand("sourcery.review_cancel_request", () => {
-      languageClient.sendRequest(ExecuteCommandRequest.type, {
-        command: "sourcery.coding_assistant",
-        arguments: [{ view: "review", request: "cancel" }],
-      });
-    })
   );
 
   context.subscriptions.push(


### PR DESCRIPTION
Refactors all the different VSCode commands into just a single one - `sourcery.coding_assistant`. The next stage will be to remove this intermediate layer altogether by removing the dependency on the `type` key.

See a small change in:

**Note:** merging to feature branch.