### PR TITLE
ci: re-add publishing to openvsx

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,7 @@ jobs:
       run: |
         yarn run vsce package
         yarn run vsce publish -p ${{ secrets.VSCE_TOKEN }}
+        yarn run ovsx publish -p ${{ secrets.OPEN_VSX_TOKEN }}
 
     - name: Upload archive
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Checklist

- [ ] If `package.json` or `yarn.lock` have changed, then test the VSIX built by `yarn run vsce package` works from a direct install
