### PR TITLE
fix: Change the Linux `Ask Sourcery` shortcut to `ctrl+shift+y`

### DIFF
--- a/package.json
+++ b/package.json
@@ -397,7 +397,7 @@
 		"keybindings": [
 			{
 				"command": "sourcery.chat.ask",
-				"linux": "ctrl+y",
+				"linux": "ctrl+shift+y",
 				"mac": "cmd+y",
 				"windows": "ctrl+shift+y",
 				"when": "editorTextFocus"


### PR DESCRIPTION
Fixes: https://github.com/sourcery-ai/sourcery-vscode/issues/204