### PR TITLE
feat: make `toggleCodeLenses` always available

### DIFF
--- a/package.json
+++ b/package.json
@@ -342,10 +342,6 @@
 					"when": "sourcery.features.coding_assistant"
 				},
 				{
-					"command": "sourcery.chat.toggleCodeLens",
-					"when": "sourcery.features.coding_assistant"
-				},
-				{
 					"command": "sourcery.scan.selectLanguage",
 					"when": "false"
 				},


### PR DESCRIPTION
Make the `toggleCodeLenses` command always available - that is, stop requiring the `coding_assistant` feature flag for it to work.