### PR TITLE
fix: adjust path parsing to allow correct URI on Windows

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -58,7 +58,9 @@ export class ChatProvider implements vscode.WebviewViewProvider {
     _token: vscode.CancellationToken
   ) {
     this._view = webviewView;
-    console.log(`Initialising webview. Assets URI: ${this._assetsUri}; Extension URI: ${this._extensionUri}`);
+    console.log(
+      `Initialising webview. Assets URI: ${this._assetsUri}; Extension URI: ${this._extensionUri}`
+    );
 
     webviewView.webview.options = {
       // Allow scripts in the webview

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -46,7 +46,10 @@ export class ChatProvider implements vscode.WebviewViewProvider {
 
   constructor(private _context: vscode.ExtensionContext) {
     this._extensionUri = _context.extensionUri;
-    this._assetsUri = vscode.Uri.file(getCodingAssistantAssetsPath());
+    const _assetsPath = getCodingAssistantAssetsPath();
+    // Parsing the path using `file` rather than `parse` allows it to work on Windows
+    // See https://github.com/microsoft/vscode-uri/blob/5af89bac2109c0dc7f904b20cc88cac0568747b1/src/uri.ts#L309-L311
+    this._assetsUri = vscode.Uri.file(_assetsPath);
   }
 
   public async resolveWebviewView(

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -46,7 +46,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
 
   constructor(private _context: vscode.ExtensionContext) {
     this._extensionUri = _context.extensionUri;
-    this._assetsUri = vscode.Uri.parse(getCodingAssistantAssetsPath());
+    this._assetsUri = vscode.Uri.file(getCodingAssistantAssetsPath());
   }
 
   public async resolveWebviewView(
@@ -55,6 +55,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
     _token: vscode.CancellationToken
   ) {
     this._view = webviewView;
+    console.log(`Initialising webview. Assets URI: ${this._assetsUri}; Extension URI: ${this._extensionUri}`);
 
     webviewView.webview.options = {
       // Allow scripts in the webview


### PR DESCRIPTION
Use `.file()` rather than `.parse()` so that windows paths are parsed correctly. `file` doesn't seem to actually need a file specifically, a directory will do.