### PR TITLE
fix: ensure directory links work in VSCode

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -170,7 +170,7 @@ export class ChatProvider implements vscode.WebviewViewProvider {
         });
       } else {
         // Reveal the directory in the explorer
-        vscode.commands.executeCommand("revealInExplorer", link);
+        vscode.commands.executeCommand("revealInExplorer", filePath);
       }
     }
   }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -170,7 +170,17 @@ export class ChatProvider implements vscode.WebviewViewProvider {
         });
       } else {
         // Reveal the directory in the explorer
-        vscode.commands.executeCommand("revealInExplorer", filePath);
+        vscode.commands
+          .executeCommand("revealInExplorer", filePath)
+          .then(() =>
+            // This is a little hack.
+            // 
+            // There's some issue with the revealInExplorer command which means when the panel changes 
+            // (e.g. from sourcery to the explorer) the instruction to actually focus the file path
+            // seems to get dropped. By calling it again (after the first command succeeds) we can 
+            // make sure the file actually gets navigated to.
+            vscode.commands.executeCommand("revealInExplorer", filePath)
+          );
       }
     }
   }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -170,17 +170,15 @@ export class ChatProvider implements vscode.WebviewViewProvider {
         });
       } else {
         // Reveal the directory in the explorer
-        vscode.commands
-          .executeCommand("revealInExplorer", filePath)
-          .then(() =>
-            // This is a little hack.
-            // 
-            // There's some issue with the revealInExplorer command which means when the panel changes 
-            // (e.g. from sourcery to the explorer) the instruction to actually focus the file path
-            // seems to get dropped. By calling it again (after the first command succeeds) we can 
-            // make sure the file actually gets navigated to.
-            vscode.commands.executeCommand("revealInExplorer", filePath)
-          );
+        vscode.commands.executeCommand("revealInExplorer", filePath).then(() =>
+          // This is a little hack.
+          //
+          // There's some issue with the revealInExplorer command which means when the panel changes
+          // (e.g. from sourcery to the explorer) the instruction to actually focus the file path
+          // seems to get dropped. By calling it again (after the first command succeeds) we can
+          // make sure the file actually gets navigated to.
+          vscode.commands.executeCommand("revealInExplorer", filePath)
+        );
       }
     }
   }


### PR DESCRIPTION
* Uses URIs in place of strings, and also adds a follow-up command to correctly focus a directory in VSCode