### PR TITLE
ci: dont publish to ovsx

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,6 @@ jobs:
       run: |
         yarn run vsce package
         yarn run vsce publish -p ${{ secrets.VSCE_TOKEN }}
-        yarn run ovsx publish -p ${{ secrets.OPEN_VSX_TOKEN }}
 
     - name: Upload archive
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Checklist

- [ ] If `package.json` or `yarn.lock` have changed, then test the VSIX built by `yarn run vsce package` works from a direct install

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI workflow by removing the step that publishes the package to the Open VSX Registry, simplifying the publishing process.

- **CI**:
    - Removed the step to publish to Open VSX Registry from the GitHub Actions workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->