### PR TITLE
feat: trying pre-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,8 +55,9 @@ jobs:
     - name: Update version number
       run: yarn run bump ${{ github.event.inputs.version }}
 
+    # TODO: Make this release not pre-release once tested.
     - name: Package VSCode extension
-      run: yarn run vsce package --target ${{matrix.target}}
+      run: yarn run vsce package --target ${{matrix.target}} --pre-release
 
     - name: Rename packaged VSIX file
       run: mv sourcery-*.vsix sourcery-${{ github.event.inputs.version }}-${{ matrix.target }}.vsix


### PR DESCRIPTION
## Checklist

- [ ] If `package.json` or `yarn.lock` have changed, then test the VSIX built by `yarn run vsce package` works from a direct install

## Summary by Sourcery

CI:
- Publish a pre-release version of the VSIX package when a new release is created.