### PR TITLE
feat: allow links in markdown hovers

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,9 @@ function createLangServer(): LanguageClient {
   };
 
   const clientOptions: LanguageClientOptions = {
+    markdown: {
+      isTrusted: true,
+    },
     diagnosticCollectionName: "sourcery",
     documentSelector: [
       { language: "*", scheme: "file" },


### PR DESCRIPTION
## Checklist

- [ ] If `package.json` or `yarn.lock` have changed, then test the VSIX built by `yarn run vsce package` works from a direct install

## Summary by Sourcery

New Features:
- Allow links in Markdown hovers.