### PR TITLE
feat: add Intel Mac (x86_64) support

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,11 +25,11 @@ jobs:
             arch: x64
             target: linux-x64
           - os: macos-latest
-            platform: mac
+            platform: mac-x86_64
             arch: x64
             target: darwin-x64
           - os: macos-latest
-            platform: mac
+            platform: mac-arm64
             arch: arm64
             target: darwin-arm64
     runs-on: ubuntu-latest

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,22 +16,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
-            platform: win
-            arch: x64
-            target: win32-x64
-          - os: ubuntu-latest
-            platform: linux
-            arch: x64
-            target: linux-x64
-          - os: macos-latest
-            platform: mac-x86_64
-            arch: x64
-            target: darwin-x64
-          - os: macos-latest
-            platform: mac-arm64
-            arch: arm64
-            target: darwin-arm64
+          - target: win32-x64
+            dir: win
+          - target: linux-x64
+            dir: linux
+          - target: darwin-x64
+            dir: mac-x86_64
+          - target: darwin-arm64
+            dir: mac-arm64
     runs-on: ubuntu-latest
 
     steps:
@@ -59,8 +51,7 @@ jobs:
       run: |
         ./download-binaries.sh ${{ github.event.inputs.version }}
         mkdir -p sourcery_binaries/install
-        rm -rf sourcery_binaries/install/*
-        mv downloaded_binaries/${{matrix.platform}}-${{matrix.arch}} sourcery_binaries/install/${{matrix.platform}}
+        mv downloaded_binaries/${{matrix.dir}} sourcery_binaries/install/
 
     - name: Update version number
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,22 +16,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
-            platform: win
-            arch: x64
-            target: win32-x64
-          - os: ubuntu-latest
-            platform: linux
-            arch: x64
-            target: linux-x64
-          - os: macos-latest
-            platform: mac-x86_64
-            arch: x64
-            target: darwin-x64
-          - os: macos-latest
-            platform: mac-arm64
-            arch: arm64
-            target: darwin-arm64
+          - target: win32-x64
+            dir: win
+          - target: linux-x64
+            dir: linux
+          - target: darwin-x64
+            dir: mac-x86_64
+          - target: darwin-arm64
+            dir: mac-arm64
     runs-on: ubuntu-latest
 
     steps:
@@ -49,8 +41,7 @@ jobs:
       run: |
         ./download-binaries.sh ${{ github.event.inputs.version }}
         mkdir -p sourcery_binaries/install
-        rm -rf sourcery_binaries/install/*
-        mv downloaded_binaries/${{matrix.platform}}-${{matrix.arch}} sourcery_binaries/install/${{matrix.platform}}
+        mv downloaded_binaries/${{matrix.dir}} sourcery_binaries/install/
 
     - name: Update version number
       run: yarn run bump ${{ github.event.inputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,11 +25,11 @@ jobs:
             arch: x64
             target: linux-x64
           - os: macos-latest
-            platform: mac
+            platform: mac-x86_64
             arch: x64
             target: darwin-x64
           - os: macos-latest
-            platform: mac
+            platform: mac-arm64
             arch: arm64
             target: darwin-arm64
     runs-on: ubuntu-latest

--- a/download-binaries.sh
+++ b/download-binaries.sh
@@ -16,28 +16,23 @@ if [[ -z $ASSETS ]]; then
   exit 1
 fi
 
-# This is where we will build the package from
-mkdir -p sourcery_binaries/install/{linux,mac-arm64,mac-x86_64,win}
-rm -rf sourcery_binaries/install/{linux,mac-arm64,mac-x86_64,win}/*
-
-# Download the binaries into here
-mkdir -p downloaded_binaries/{linux-x64,mac-arm64,mac-x86_64,win-x64}
-rm -rf downloaded_binaries/{linux-x64,mac-arm64,mac-x86_64,win-x64}/*
-
+# Download binaries - directory names match install directories
+mkdir -p downloaded_binaries/{linux,mac-arm64,mac-x86_64,win}
+rm -rf downloaded_binaries/{linux,mac-arm64,mac-x86_64,win}/*
 
 echo Downloading linux binary
 curl -s -L $( echo $ASSETS | jq -r ".[] | select(.name == \"sourcery-$VERSION-linux.tar.gz\") | .browser_download_url" ) \
-  | tar -xz -C downloaded_binaries/linux-x64
+  | tar -xz -C downloaded_binaries/linux
 
 echo Downloading mac arm64 binary
 curl -s -L $( echo $ASSETS | jq -r ".[] | select(.name == \"sourcery-$VERSION-mac-arm64.tar.gz\") | .browser_download_url" ) \
   | tar -xz -C downloaded_binaries/mac-arm64
 
-echo Downloading mac intel binary
+echo Downloading mac x86_64 binary
 curl -s -L $( echo $ASSETS | jq -r ".[] | select(.name == \"sourcery-$VERSION-mac-x86_64.tar.gz\") | .browser_download_url" ) \
   | tar -xz -C downloaded_binaries/mac-x86_64
 
 echo Downloading windows binary
 curl -s -L $( echo $ASSETS | jq -r ".[] | select(.name == \"sourcery-$VERSION-win.zip\") | .browser_download_url" ) -o temp.zip
-unzip temp.zip -d downloaded_binaries/win-x64/
+unzip temp.zip -d downloaded_binaries/win/
 rm temp.zip

--- a/download-binaries.sh
+++ b/download-binaries.sh
@@ -17,12 +17,12 @@ if [[ -z $ASSETS ]]; then
 fi
 
 # This is where we will build the package from
-mkdir -p sourcery_binaries/install/{linux,mac,win}
-rm -rf sourcery_binaries/install/{linux,mac,win}/*
+mkdir -p sourcery_binaries/install/{linux,mac-arm64,mac-x86_64,win}
+rm -rf sourcery_binaries/install/{linux,mac-arm64,mac-x86_64,win}/*
 
 # Download the binaries into here
-mkdir -p downloaded_binaries/{linux-x64,mac-arm64,mac-x64,win-x64}
-rm -rf downloaded_binaries/{linux-x64,mac-arm64,mac-x64,win-x64}/*
+mkdir -p downloaded_binaries/{linux-x64,mac-arm64,mac-x86_64,win-x64}
+rm -rf downloaded_binaries/{linux-x64,mac-arm64,mac-x86_64,win-x64}/*
 
 
 echo Downloading linux binary
@@ -35,7 +35,7 @@ curl -s -L $( echo $ASSETS | jq -r ".[] | select(.name == \"sourcery-$VERSION-ma
 
 echo Downloading mac intel binary
 curl -s -L $( echo $ASSETS | jq -r ".[] | select(.name == \"sourcery-$VERSION-mac-x86_64.tar.gz\") | .browser_download_url" ) \
-  | tar -xz -C downloaded_binaries/mac-x64
+  | tar -xz -C downloaded_binaries/mac-x86_64
 
 echo Downloading windows binary
 curl -s -L $( echo $ASSETS | jq -r ".[] | select(.name == \"sourcery-$VERSION-win.zip\") | .browser_download_url" ) -o temp.zip

--- a/src/executable.ts
+++ b/src/executable.ts
@@ -58,7 +58,8 @@ export function getExecutablePath(): string {
     if (process.platform == "win32") {
       return path.join(sourcery_binaries, "install/win/sourcery.exe");
     } else if (process.platform == "darwin") {
-      return path.join(sourcery_binaries, "install/mac/sourcery");
+      const macDir = process.arch == "arm64" ? "mac-arm64" : "mac-x86_64";
+      return path.join(sourcery_binaries, "install", macDir, "sourcery");
     } else {
       // Assume everything else is linux compatible
       return path.join(sourcery_binaries, "install/linux/sourcery");


### PR DESCRIPTION
## Summary
- Update CI matrix to use `mac-arm64`/`mac-x86_64` directory names
- Update `executable.ts` to detect architecture via `process.arch`
- Update `download-binaries.sh` directory names

This change is needed to support Intel Mac users and align with the updater's new directory structure. Companion PRs in intellij-plugin and core.

## Test plan
- [ ] Build and test on ARM Mac
- [ ] Build and test on Intel Mac
- [ ] Verify updater works after initial install

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add architecture-specific macOS support by splitting mac binaries and directory names into separate arm64 and x86_64 variants and wiring selection into the executable path resolution.

New Features:
- Support separate Intel (x86_64) and Apple Silicon (arm64) macOS binaries in the packaged artifacts.

Enhancements:
- Update executable path resolution to choose the correct macOS binary based on process architecture.
- Align local binary download and installation directory layout with the new macOS architecture-specific structure.

CI:
- Adjust prerelease and publish GitHub Actions matrices to use distinct mac-arm64 and mac-x86_64 platforms.