### PR TITLE
fix: skip activation on unsupported platforms

### DIFF
--- a/src/executable.ts
+++ b/src/executable.ts
@@ -12,8 +12,8 @@ const SUPPORTED_ARCHS: Partial<
 };
 
 export type UnsupportedPlatform = {
-  platform: string;
-  arch: string;
+  platform: NodeJS.Platform;
+  arch: NodeJS.Architecture;
 };
 
 export function getUnsupportedPlatform(): UnsupportedPlatform | null {

--- a/src/executable.ts
+++ b/src/executable.ts
@@ -3,6 +3,32 @@
 import * as path from "path";
 import * as fs from "fs";
 
+const SUPPORTED_ARCHS: Partial<
+  Record<NodeJS.Platform, ReadonlyArray<NodeJS.Architecture>>
+> = {
+  win32: ["x64"],
+  darwin: ["x64", "arm64"],
+  linux: ["x64"],
+};
+
+export type UnsupportedPlatform = {
+  platform: string;
+  arch: string;
+};
+
+export function getUnsupportedPlatform(): UnsupportedPlatform | null {
+  // SOURCERY_EXECUTABLE points at a custom binary (development, custom builds);
+  // if it's set we trust the caller and skip the arch check.
+  if (process.env.SOURCERY_EXECUTABLE) {
+    return null;
+  }
+  const archs = SUPPORTED_ARCHS[process.platform];
+  if (archs && archs.includes(process.arch)) {
+    return null;
+  }
+  return { platform: process.platform, arch: process.arch };
+}
+
 export function getCodingAssistantAssetsPath(): string {
   // Allow complete local override
   if (process.env.SOURCERY_CODING_ASSISTANT_ASSETS_PATH) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,11 @@
 "use strict";
 
 import * as path from "path";
-import { getExecutablePath } from "./executable";
+import {
+  getExecutablePath,
+  getUnsupportedPlatform,
+  UnsupportedPlatform,
+} from "./executable";
 
 import * as vscode from "vscode";
 import {
@@ -489,7 +493,35 @@ function registerCommands(
   );
 }
 
+const UNSUPPORTED_ARCH_WARNING_KEY = "sourcery.unsupportedArchWarningShown";
+
+function warnUnsupportedPlatform(
+  context: ExtensionContext,
+  unsupported: UnsupportedPlatform
+): void {
+  const archKey = `${unsupported.platform}-${unsupported.arch}`;
+  console.warn(
+    `Sourcery: unsupported platform ${archKey}; not starting language server.`
+  );
+  const lastShown = context.globalState.get<string>(
+    UNSUPPORTED_ARCH_WARNING_KEY
+  );
+  if (lastShown === archKey) {
+    return;
+  }
+  window.showWarningMessage(
+    `Sourcery does not support ${unsupported.platform} on ${unsupported.arch} and will stay idle on this machine.`
+  );
+  context.globalState.update(UNSUPPORTED_ARCH_WARNING_KEY, archKey);
+}
+
 export function activate(context: ExtensionContext) {
+  const unsupported = getUnsupportedPlatform();
+  if (unsupported) {
+    warnUnsupportedPlatform(context, unsupported);
+    return;
+  }
+
   const languageClient = createLangServer();
   let hubWebviewPanel: WebviewPanel | undefined = undefined;
 


### PR DESCRIPTION
Closes #275.

On linux-arm64 (e.g. Raspberry Pi) the kernel rejects our x86_64 binary with `ENOEXEC`. glibc then falls back to `/bin/sh sourcery lsp`, which parses the ELF as a shell script — and one of the bytes lands as a `>` redirection, creating an empty file named `\x01` in the workspace root on every LSP start.

Fix: gate `activate()` on `process.platform`/`process.arch`. If the combination isn't one we ship a binary for, we skip the language client entirely and show a one-time warning toast (suppressed thereafter via `globalState`). `SOURCERY_EXECUTABLE` overrides the check for local/custom builds.

## Test plan
- [ ] On a supported platform (darwin-arm64), extension activates normally — no toast, LSP starts.
- [ ] Force `process.platform = 'linux'` + `process.arch = 'arm64'` (or run on a Pi): warning toast appears once, no `\x01` file in workspace, no LSP process spawned.
- [ ] Restart VS Code on the same unsupported arch: no toast (silent).
- [ ] `SOURCERY_EXECUTABLE=...` set: check is bypassed, activation proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Gate extension activation on supported OS/architecture combinations to avoid starting the language server on unsupported platforms.

Bug Fixes:
- Prevent the language server from attempting to start on unsupported platform/architecture combinations, avoiding spurious file creation and startup errors.

Enhancements:
- Add platform/architecture detection with an environment variable escape hatch for custom SOURCERY_EXECUTABLE builds.
- Show a one-time warning message when running on an unsupported platform, persisted via global state to avoid repeated toasts.