### PR TITLE
fix(ci): make the publish workflow safe to re-dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,9 +82,18 @@ jobs:
         git add .
         git config --global user.name ${{ github.actor }}
         git config --global user.email ${{ github.actor }}@users.noreply.github.com
-        git commit -m 'Update version number to v${{ github.event.inputs.version }}'
-        git tag v${{ github.event.inputs.version }}
-        git push origin main v${{ github.event.inputs.version }}
+        if git diff --cached --quiet; then
+          echo "Version files unchanged - skipping commit on re-run"
+        else
+          git commit -m 'Update version number to v${{ github.event.inputs.version }}'
+        fi
+        if git ls-remote --exit-code --tags origin v${{ github.event.inputs.version }} > /dev/null; then
+          echo "Tag v${{ github.event.inputs.version }} already exists - pushing main only"
+          git push origin main
+        else
+          git tag v${{ github.event.inputs.version }}
+          git push origin main v${{ github.event.inputs.version }}
+        fi
       env:
         GITHUB_TOKEN: ${{ secrets.SOURCERY_RELEASE_TOKEN }}
 
@@ -115,8 +124,12 @@ jobs:
     - name: Update version number to dev
       run: |
         yarn run bump prepatch --preid dev
-        git commit -am 'Bump version to dev'
-        git push origin main
+        if git diff --quiet; then
+          echo "Version files unchanged - skipping commit on re-run"
+        else
+          git commit -am 'Bump version to dev'
+          git push origin main
+        fi
       env:
         GITHUB_TOKEN: ${{ secrets.SOURCERY_RELEASE_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,19 +38,25 @@ jobs:
     - run: yarn install --frozen-lockfile
 
     - name: Update binaries
+      env:
+        VERSION: ${{ github.event.inputs.version }}
       run: |
-        ./download-binaries.sh ${{ github.event.inputs.version }}
+        ./download-binaries.sh "$VERSION"
         mkdir -p sourcery_binaries/install
         mv downloaded_binaries/${{matrix.dir}} sourcery_binaries/install/
 
     - name: Update version number
-      run: yarn run bump ${{ github.event.inputs.version }}
+      env:
+        VERSION: ${{ github.event.inputs.version }}
+      run: yarn run bump "$VERSION"
 
     - name: Package VSCode extension
       run: yarn run vsce package --target ${{matrix.target}}
 
     - name: Rename packaged VSIX file
-      run: mv sourcery-*.vsix sourcery-${{ github.event.inputs.version }}-${{ matrix.target }}.vsix
+      env:
+        VERSION: ${{ github.event.inputs.version }}
+      run: mv sourcery-*.vsix "sourcery-${VERSION}-${{ matrix.target }}.vsix"
 
     - name: Upload archive
       uses: actions/upload-artifact@v4
@@ -67,6 +73,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.SOURCERY_RELEASE_TOKEN }}
+        # always the current branch tip, so a job re-run after a partial
+        # failure sees any bump commit the previous attempt already pushed
+        ref: main
 
     - uses: actions/setup-node@v3
       with:
@@ -75,7 +84,9 @@ jobs:
     - run: yarn install --frozen-lockfile
 
     - name: Update version number
-      run: yarn run bump ${{ github.event.inputs.version }}
+      env:
+        VERSION: ${{ github.event.inputs.version }}
+      run: yarn run bump "$VERSION"
 
     - name: Commit to main, create tag, and push
       run: |
@@ -85,17 +96,23 @@ jobs:
         if git diff --cached --quiet; then
           echo "Version files unchanged - skipping commit on re-run"
         else
-          git commit -m 'Update version number to v${{ github.event.inputs.version }}'
+          git commit -m "Update version number to v${VERSION}"
         fi
-        if git ls-remote --exit-code --tags origin v${{ github.event.inputs.version }} > /dev/null; then
-          echo "Tag v${{ github.event.inputs.version }} already exists - pushing main only"
+        TAG_SHA=$(git ls-remote --tags origin "refs/tags/v${VERSION}" | cut -f1)
+        if [ -n "$TAG_SHA" ]; then
+          if [ "$TAG_SHA" != "$(git rev-parse HEAD)" ]; then
+            echo "Tag v${VERSION} already exists but points at ${TAG_SHA}, not the release commit $(git rev-parse HEAD) - move or delete the tag before re-running"
+            exit 1
+          fi
+          echo "Tag v${VERSION} already exists - pushing main only"
           git push origin main
         else
-          git tag v${{ github.event.inputs.version }}
-          git push origin main v${{ github.event.inputs.version }}
+          git tag "v${VERSION}"
+          git push origin main "v${VERSION}"
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.SOURCERY_RELEASE_TOKEN }}
+        VERSION: ${{ github.event.inputs.version }}
 
     - name: Download artifacts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
The 1.44.0 publish failed at `vsce publish` (expired `VSCE_TOKEN`) **after** the version-bump commit had already been pushed to main. That leaves the workflow unrecoverable:

- **Job re-run**: checks out the frozen pre-bump SHA, creates a duplicate bump commit, and gets its `git push origin main` rejected (this is exactly what happened in [the 18:38 re-run attempt](https://github.com/sourcery-ai/sourcery-vscode/actions/runs/29925868761/job/89016531834), which also left tag v1.44.0 pointing at an off-main commit — since retagged onto `a843712`).
- **Fresh dispatch**: checks out current main (already bumped), `bump` is a no-op, and `git commit` fails with *nothing to commit*.

This applies the same treatment as sourcery-ai/core#6406 gave `build_sourcery.yml`:

- skip the version-bump commit when `git diff --cached --quiet` (already bumped)
- skip tagging when the tag already exists on the remote (`git ls-remote`), pushing only main
- skip the final dev-bump commit when it produced no changes

`bump <same-version>` is already idempotent (verified with version-bump-prompt 6: exit 0, *"package.json did not need to be updated"*), so no guard is needed on the bump steps themselves.

After merging, complete the 1.44.0 publish with a **fresh dispatch** of "Publish VSIX" (version `1.44.0`) — not a re-run, so it picks up this workflow definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the publish workflow resilient to re-dispatches after a version bump has already been pushed.

Build:
- Add guards in the publish workflow to skip creating a duplicate version-bump commit when no changes are staged.
- Avoid re-creating and pushing a version tag if it already exists on the remote, only pushing main in that case.
- Skip the final dev-bump commit and push when the bump step produces no changes, allowing safe workflow re-runs.