### PR TITLE
fix(ci): accept an existing release tag anywhere on main, not only at HEAD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,9 @@ jobs:
         # always the current branch tip, so a job re-run after a partial
         # failure sees any bump commit the previous attempt already pushed
         ref: main
+        # full history so the tag-ancestry check below can resolve the
+        # existing tag's commit
+        fetch-depth: 0
 
     - uses: actions/setup-node@v3
       with:
@@ -100,11 +103,11 @@ jobs:
         fi
         TAG_SHA=$(git ls-remote --tags origin "refs/tags/v${VERSION}" | cut -f1)
         if [ -n "$TAG_SHA" ]; then
-          if [ "$TAG_SHA" != "$(git rev-parse HEAD)" ]; then
-            echo "Tag v${VERSION} already exists but points at ${TAG_SHA}, not the release commit $(git rev-parse HEAD) - move or delete the tag before re-running"
+          if ! git merge-base --is-ancestor "$TAG_SHA" HEAD; then
+            echo "Tag v${VERSION} already exists but points at ${TAG_SHA}, which is not on main - move or delete the tag before re-running"
             exit 1
           fi
-          echo "Tag v${VERSION} already exists - pushing main only"
+          echo "Tag v${VERSION} already exists on main - pushing main only"
           git push origin main
         else
           git tag "v${VERSION}"


### PR DESCRIPTION
Follow-up to #285. The guard it added compared an existing tag against HEAD, but any fix merged between a failed publish and its re-run advances main past the tag — which is exactly what happened on [run 29951222947](https://github.com/sourcery-ai/sourcery-vscode/actions/runs/29951222947) when #285 itself merged: tag `v1.44.0` pointed at the bump commit `a843712`, main's tip was the #285 merge, and the guard refused a perfectly good state.

This switches the check to ancestry: a tag anywhere on main's history is accepted (push main only, release attaches to the tag), while a tag pointing at an off-main commit — the actual hazard the guard exists for — still fails with the same loud message. The checkout gets `fetch-depth: 0` so `git merge-base --is-ancestor` can resolve the tag's commit from a previously-shallow clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update publish workflow checkout to use full history and switch tag validation from HEAD equality to an ancestry check, allowing re-runs when main has advanced beyond the release tag.